### PR TITLE
adds support for max_replicas_per_node and placement preferences

### DIFF
--- a/src/main/kotlin/de/gesellix/docker/compose/types/Deploy.kt
+++ b/src/main/kotlin/de/gesellix/docker/compose/types/Deploy.kt
@@ -16,5 +16,7 @@ data class Deploy(
         var restartPolicy: RestartPolicy? = null,
         var placement: Placement? = null,
         @Json(name = "endpoint_mode")
-        var endpointMode: String? = null
+        var endpointMode: String? = null,
+        @Json(name = "max_replicas_per_node")
+        var maxReplicasPerNode: Int? = null
 )

--- a/src/main/kotlin/de/gesellix/docker/compose/types/Placement.kt
+++ b/src/main/kotlin/de/gesellix/docker/compose/types/Placement.kt
@@ -2,5 +2,7 @@ package de.gesellix.docker.compose.types
 
 data class Placement(
 
-        var constraints: List<String>? = null
+        var constraints: List<String>? = null,
+        var preferences: List<PlacementPreferences>? = null
+
 )

--- a/src/main/kotlin/de/gesellix/docker/compose/types/PlacementPreferences.kt
+++ b/src/main/kotlin/de/gesellix/docker/compose/types/PlacementPreferences.kt
@@ -1,0 +1,7 @@
+package de.gesellix.docker.compose.types
+
+data class PlacementPreferences(
+
+        var spread: String
+
+)


### PR DESCRIPTION
Adds support for parsing the following attributes that belong to the deploy section:

- [max_replicas_per_node](https://docs.docker.com/compose/compose-file/#max_replicas_per_node)
- [placement preferences](https://docs.docker.com/compose/compose-file/#placement)