### PR TITLE
bugfix: the parsing of a expanded volumes block with a nocopy entry triggered an exception

### DIFF
--- a/src/main/kotlin/de/gesellix/docker/compose/adapters/ListToServiceVolumesAdapter.kt
+++ b/src/main/kotlin/de/gesellix/docker/compose/adapters/ListToServiceVolumesAdapter.kt
@@ -81,6 +81,24 @@ class ListToServiceVolumesAdapter {
                             val value = reader.nextInt()
                             writePropery(volume, name, value)
                         }
+                        JsonReader.Token.BEGIN_OBJECT -> {
+                            reader.beginObject()
+                            val volumeVolume = ServiceVolumeVolume()
+                            while (reader.hasNext()) {
+                                val name = reader.nextName()
+                                when (reader.peek()) {
+                                    JsonReader.Token.BOOLEAN -> {
+                                        val value = reader.nextBoolean()
+                                        writePropery(volumeVolume, name, value)
+                                    }
+                                    else -> {
+                                        // ...
+                                    }
+                                }
+                            }
+                            reader.endObject()
+                            writePropery(volume, name, volumeVolume)
+                        }
                         else -> {
                             // ...
                         }

--- a/src/main/kotlin/de/gesellix/docker/compose/types/ServiceVolumeVolume.kt
+++ b/src/main/kotlin/de/gesellix/docker/compose/types/ServiceVolumeVolume.kt
@@ -2,5 +2,5 @@ package de.gesellix.docker.compose.types
 
 data class ServiceVolumeVolume(
 
-        var noCopy: Boolean
+        var nocopy: Boolean = false
 )

--- a/src/test/kotlin/de/gesellix/docker/compose/ComposeFileReaderTest.kt
+++ b/src/test/kotlin/de/gesellix/docker/compose/ComposeFileReaderTest.kt
@@ -218,6 +218,18 @@ class ComposeFileReaderTest : DescribeSpec({
         assertEquals(ServiceVolumeType.TypeBind.typeName, result.services!!.getValue("foo").volumes!!.first().type)
       }
     }
+
+    context("volumes_nocopy/sample.yaml") {
+
+      val composeFile = ComposeFileReaderTest::class.java.getResource("volumes_nocopy/sample.yaml")
+      val workingDir = Paths.get(composeFile.toURI()).parent.toString()
+      val result = ComposeFileReader().load(composeFile.openStream(), workingDir, System.getenv())!!
+
+      it("should set volume type and nocopy") {
+        assertEquals(ServiceVolumeType.TypeVolume.typeName, result.services!!.getValue("foo").volumes!!.first().type)
+        assertTrue(result.services!!.getValue("foo").volumes!!.first().volume!!.nocopy)
+      }
+    }
   }
 
   describe("configs") {

--- a/src/test/resources/de/gesellix/docker/compose/volumes_nocopy/sample.yaml
+++ b/src/test/resources/de/gesellix/docker/compose/volumes_nocopy/sample.yaml
@@ -1,0 +1,10 @@
+version: "3"
+services:
+  foo:
+    image: busybox
+    volumes:
+      - source: myvol
+        target: /foo
+        type: volume
+        volume:
+          nocopy: true


### PR DESCRIPTION
When attempting to parse the following compose file:
```
version: "3"
services:
  foo:
    image: busybox
    volumes:
      - source: myvol
        target: /foo
        type: volume
        volume:
          nocopy: true
```

The library triggers the following exception:
```
com.squareup.moshi.JsonDataException: com.squareup.moshi.JsonDataException: Expected NAME but was {nocopy=true}, a java.util.HashMap, at path $.services.foo.volumes[0].volume at $.services.foo.volumes[0].volume
	at com.squareup.moshi.AdapterMethodsFactory$1.fromJson(AdapterMethodsFactory.java:101)
	at com.squareup.moshi.kotlin.reflect.KotlinJsonAdapter.fromJson(KotlinJsonAdapter.kt:86)
	at com.squareup.moshi.internal.NullSafeJsonAdapter.fromJson(NullSafeJsonAdapter.java:41)
```

This merge request is intended to fix this by properly parsing the nocopy information.