### PR TITLE
bugfix: parsing a bind mount (short syntax) which contains a 0 in its name fails

### DIFF
--- a/src/main/kotlin/de/gesellix/docker/compose/adapters/ListToServiceVolumesAdapter.kt
+++ b/src/main/kotlin/de/gesellix/docker/compose/adapters/ListToServiceVolumesAdapter.kt
@@ -48,21 +48,19 @@ class ListToServiceVolumesAdapter {
                             target = value))
                 }
 
-                val endOfSpec = '0'
-                val spec = "$value$endOfSpec"
-
                 val volume = ServiceVolume()
                 var buf = ""
-                for (char in spec) {
+                for (char in value) {
                     buf = if (isWindowsDrive(buf, char)) {
                         "$buf$char"
-                    } else if (char == ':' || char == endOfSpec) {
-                        populateFieldFromBuffer(char, buf, volume)
+                    } else if (char == ':') {
+                        populateFieldFromBuffer(false, buf, volume)
                         ""
                     } else {
                         "$buf$char"
                     }
                 }
+                populateFieldFromBuffer(true, buf, volume)
 
                 populateType(volume)
                 return listOf(volume)
@@ -122,12 +120,12 @@ class ListToServiceVolumesAdapter {
 //        return firstTwoChars.first().isLetter() && firstTwoChars.last() == ':'
     }
 
-    private fun populateFieldFromBuffer(char: Char, buffer: String, volume: ServiceVolume) {
-        if (buffer.isEmpty()) {
+    private fun populateFieldFromBuffer(endOfInput: Boolean, buffer: String, volume: ServiceVolume) {
+        if (!endOfInput && buffer.isEmpty()) {
             throw IllegalStateException("empty section between colons")
         }
 
-        if (volume.source.isEmpty() && char == '0') {
+        if (volume.source.isEmpty() && endOfInput) {
             volume.target = buffer
             return
         } else if (volume.source.isEmpty()) {
@@ -138,7 +136,7 @@ class ListToServiceVolumesAdapter {
             return
         }
 
-        if (char == ':') {
+        if (!endOfInput) {
             throw IllegalStateException("too many colons")
         }
 

--- a/src/test/kotlin/de/gesellix/docker/compose/ComposeFileReaderTest.kt
+++ b/src/test/kotlin/de/gesellix/docker/compose/ComposeFileReaderTest.kt
@@ -219,6 +219,33 @@ class ComposeFileReaderTest : DescribeSpec({
       }
     }
 
+    context("volumes_zeroinpath/sample.yaml") {
+
+      val composeFile = ComposeFileReaderTest::class.java.getResource("volumes_zeroinpath/sample.yaml")
+      val workingDir = Paths.get(composeFile.toURI()).parent.toString()
+      val result = ComposeFileReader().load(composeFile.openStream(), workingDir, System.getenv())!!
+
+      it("should parse source and target correctly") {
+        assertEquals(ServiceVolumeType.TypeBind.typeName, result.services!!.getValue("foo").volumes!!.first().type)
+        assertEquals("/data/shared_apps/app/acc-70/data", result.services!!.getValue("foo").volumes!!.first().source)
+        assertEquals("/data", result.services!!.getValue("foo").volumes!!.first().target)
+      }
+    }
+
+    context("volumes_readonly_shortsyntax/sample.yaml") {
+
+      val composeFile = ComposeFileReaderTest::class.java.getResource("volumes_readonly_shortsyntax/sample.yaml")
+      val workingDir = Paths.get(composeFile.toURI()).parent.toString()
+      val result = ComposeFileReader().load(composeFile.openStream(), workingDir, System.getenv())!!
+
+      it("should parse source and target correctly") {
+        assertEquals(ServiceVolumeType.TypeBind.typeName, result.services!!.getValue("foo").volumes!!.first().type)
+        assertEquals("/data/shared_apps/app/acc/data", result.services!!.getValue("foo").volumes!!.first().source)
+        assertEquals("/data", result.services!!.getValue("foo").volumes!!.first().target)
+        assertTrue(result.services!!.getValue("foo").volumes!!.first().readOnly)
+      }
+    }
+
     context("volumes_nocopy/sample.yaml") {
 
       val composeFile = ComposeFileReaderTest::class.java.getResource("volumes_nocopy/sample.yaml")

--- a/src/test/resources/de/gesellix/docker/compose/volumes_readonly_shortsyntax/sample.yaml
+++ b/src/test/resources/de/gesellix/docker/compose/volumes_readonly_shortsyntax/sample.yaml
@@ -1,0 +1,6 @@
+version: "3"
+services:
+  foo:
+    image: busybox
+    volumes:
+      - '/data/shared_apps/app/acc/data:/data:ro'

--- a/src/test/resources/de/gesellix/docker/compose/volumes_zeroinpath/sample.yaml
+++ b/src/test/resources/de/gesellix/docker/compose/volumes_zeroinpath/sample.yaml
@@ -1,0 +1,6 @@
+version: "3"
+services:
+  foo:
+    image: busybox
+    volumes:
+      - '/data/shared_apps/app/acc-70/data:/data'


### PR DESCRIPTION
When we attempt to parse a docker-compose file where there is a bind mount (in short syntax), which has a "0" in its name. The parser drastically fails.