### PR TITLE
Add 'start_interval' to Healthcheck

### DIFF
--- a/src/main/kotlin/de/gesellix/docker/compose/types/Healthcheck.kt
+++ b/src/main/kotlin/de/gesellix/docker/compose/types/Healthcheck.kt
@@ -12,5 +12,7 @@ data class Healthcheck(
         var test: Command = Command(),
         var timeout: String? = null,
         @Json(name = "start_period")
-        var startPeriod: String? = null
+        var startPeriod: String? = null,
+        @Json(name = "start_interval")
+        var startInterval: String? = null
 )

--- a/src/test/kotlin/de/gesellix/docker/compose/ComposeFileReaderTest.kt
+++ b/src/test/kotlin/de/gesellix/docker/compose/ComposeFileReaderTest.kt
@@ -524,7 +524,8 @@ fun newSampleConfigFull(): ComposeConfig {
       retries = 5f,
       test = Command(parts = arrayListOf("echo \"hello world\"")),
       timeout = "1s",
-      startPeriod = "1s"
+      startPeriod = "1s",
+      startInterval = "500ms"
     ),
     hostname = "foo",
     image = "redis",

--- a/src/test/resources/de/gesellix/docker/compose/full/sample.yaml
+++ b/src/test/resources/de/gesellix/docker/compose/full/sample.yaml
@@ -115,6 +115,7 @@ services:
       timeout: 1s
       retries: 5
       start_period: 1s
+      start_interval: 500ms
 
     # Any valid image reference - repo, tag, id, sha
     image: redis


### PR DESCRIPTION
This PR adds the new `start_interval` field to Healthcheck. If you want I could also make a PR in [docker-client](https://github.com/gesellix/docker-client/). Let me know.